### PR TITLE
Use pin-project and tokio::pin instead of unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ edition = "2018"
 [dependencies]
 base64 = "0.13.0"
 hyper = { version = "0.14.4" }
+pin-project = "1"
 sha-1 = "0.9.3"
+tokio = "1.2.0"
 tokio-tungstenite = "0.14.0"
 
 [dev-dependencies]


### PR DESCRIPTION
When choosing between `pin-project` and `pin-project-lite` I've opted for the former mostly because of the "version = 1" guarantees. Both `hyper` and `tokio-tungstenite` use it, so nothing new gets added to the actual dependencies.