### PR TITLE
Remove local convert_key function since tungstenite already exposes a similar one.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,8 @@ documentation = "https://docs.rs/hyper-tungstenite"
 edition = "2018"
 
 [dependencies]
-base64 = "0.13.0"
 hyper = { version = "0.14.4" }
 pin-project = "1"
-sha-1 = "0.9.3"
 tokio = "1.2.0"
 tokio-tungstenite = "0.14.0"
 


### PR DESCRIPTION
Tungstenite already exposed `derive_accept_key` since v0.13 so no need for the duplicate.