### PR TITLE
Bump tokio-tungstenite version to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 hyper = { version = "0.14.4" }
 pin-project = "1"
 tokio = "1.2.0"
-tokio-tungstenite = "0.15.0"
+tokio-tungstenite = "0.15"
 
 [dev-dependencies]
 assert2 = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 hyper = { version = "0.14.4" }
 pin-project = "1"
 tokio = "1.2.0"
-tokio-tungstenite = "0.14.0"
+tokio-tungstenite = "0.15.0"
 
 [dev-dependencies]
 assert2 = "0.3.4"


### PR DESCRIPTION
Build and tests seem to be passing with no required change.