### PR TITLE
chore!: don't consume request for upgrade

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,9 +127,11 @@ pub struct HyperWebsocket {
 /// Alternatively you can inspect the `Connection` and `Upgrade` headers manually.
 ///
 pub fn upgrade(
-	request: &mut Request<Body>,
+	mut request: impl std::borrow::BorrowMut<Request<Body>>,
 	config: Option<WebSocketConfig>,
 ) -> Result<(Response<Body>, HyperWebsocket), ProtocolError> {
+	let request = request.borrow_mut();
+
 	let key = request.headers().get("Sec-WebSocket-Key")
 		.ok_or(ProtocolError::MissingSecWebSocketKey)?;
 	if request.headers().get("Sec-WebSocket-Version").map(|v| v.as_bytes()) != Some(b"13") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,10 @@
 //! type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 //!
 //! /// Handle a HTTP or WebSocket request.
-//! async fn handle_request(request: Request<Body>) -> Result<Response<Body>, Error> {
+//! async fn handle_request(mut request: Request<Body>) -> Result<Response<Body>, Error> {
 //!     // Check if the request is a websocket upgrade request.
 //!     if hyper_tungstenite::is_upgrade_request(&request) {
-//!         let (response, websocket) = hyper_tungstenite::upgrade(request, None)?;
+//!         let (response, websocket) = hyper_tungstenite::upgrade(&mut request, None)?;
 //!
 //!         // Spawn a task to handle the websocket connection.
 //!         tokio::spawn(async move {
@@ -127,7 +127,7 @@ pub struct HyperWebsocket {
 /// Alternatively you can inspect the `Connection` and `Upgrade` headers manually.
 ///
 pub fn upgrade(
-	request: Request<Body>,
+	request: &mut Request<Body>,
 	config: Option<WebSocketConfig>,
 ) -> Result<(Response<Body>, HyperWebsocket), ProtocolError> {
 	let key = request.headers().get("Sec-WebSocket-Key")

--- a/tests/simple-server.rs
+++ b/tests/simple-server.rs
@@ -36,10 +36,10 @@ async fn hyper() {
 	assert!(let Some(Ok(Message::Close(None))) = stream.next().await);
 }
 
-async fn upgrade_websocket(request: Request<Body>) -> Result<Response<Body>> {
+async fn upgrade_websocket(mut request: Request<Body>) -> Result<Response<Body>> {
 	assert!(hyper_tungstenite::is_upgrade_request(&request) == true);
 
-	let (response, stream) = hyper_tungstenite::upgrade(request, None)
+	let (response, stream) = hyper_tungstenite::upgrade(&mut request, None)
 		.map_err(Error::Protocol)?;
 	tokio::spawn(async move {
 		let_assert!(Ok(mut stream) = stream.await);

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -36,10 +36,10 @@ async fn hyper() {
 	assert!(let Some(Ok(Message::Close(None))) = stream.next().await);
 }
 
-async fn upgrade_websocket(request: Request<Body>) -> Result<Response<Body>> {
+async fn upgrade_websocket(mut request: Request<Body>) -> Result<Response<Body>> {
 	assert!(hyper_tungstenite::is_upgrade_request(&request) == true);
 
-	let (response, stream) = hyper_tungstenite::upgrade(request, None)
+	let (response, stream) = hyper_tungstenite::upgrade(&mut request, None)
 		.map_err(Error::Protocol)?;
 	tokio::spawn(async move {
 		let_assert!(Ok(stream) = stream.await);


### PR DESCRIPTION
`hyper::upgrade` accepts a mutable reference to a request.

<https://docs.rs/hyper/latest/hyper/upgrade/fn.on.html>