### PR TITLE
chore: allow arbitrary body types for `upgrade`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# main
+* Allow arbitrary body types in the `Request` passed to `upgrade`.
+
 # v0.7.0 - 2022-02-25
 * Accept either a `Request` or `&mut Request` when upgrading a connection.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@ pub struct HyperWebsocket {
 /// To check if a request is a websocket upgrade request, you can use [`is_upgrade_request`].
 /// Alternatively you can inspect the `Connection` and `Upgrade` headers manually.
 ///
-pub fn upgrade(
-	mut request: impl std::borrow::BorrowMut<Request<Body>>,
+pub fn upgrade<B>(
+	mut request: impl std::borrow::BorrowMut<Request<B>>,
 	config: Option<WebSocketConfig>,
 ) -> Result<(Response<Body>, HyperWebsocket), ProtocolError> {
 	let request = request.borrow_mut();


### PR DESCRIPTION
- `is_upgrade_request` already allows arbitrary body types