### PR TITLE
Documentation: Add missing enum case to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ async fn serve_websocket(websocket: HyperWebsocket) -> Result<(), Error> {
                 }
             },
             Message::Frame(_) => {
+                // You will never get a raw frame when reading messages.
                 unreachable!();
             },
         }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ async fn serve_websocket(websocket: HyperWebsocket) -> Result<(), Error> {
                     println!("Received close message");
                 }
             },
+            Message::Frame(_) => {
+                unreachable!();
+            },
         }
     }
 


### PR DESCRIPTION
The missing enum case to the README