### PR TITLE
Replace `pin-project` with `pin-project-lite`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 
 [dependencies]
 hyper = { version = "0.14.4" }
-pin-project = "1.0.8"
+pin-project-lite = "0.2.10"
 tokio = "1.2.0"
 tokio-tungstenite = "0.19.0"
 tungstenite = "0.19.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@
 use hyper::{Body, Request, Response};
 use std::task::{Context, Poll};
 use std::pin::Pin;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 use tungstenite::{Error, error::ProtocolError};
 use tungstenite::handshake::derive_accept_key;
@@ -117,13 +117,14 @@ pub use tungstenite;
 
 pub use tokio_tungstenite::WebSocketStream;
 
-/// A future that resolves to a websocket stream when the associated HTTP upgrade completes.
-#[pin_project]
-#[derive(Debug)]
-pub struct HyperWebsocket {
-	#[pin]
-	inner: hyper::upgrade::OnUpgrade,
-	config: Option<WebSocketConfig>,
+pin_project! {
+	/// A future that resolves to a websocket stream when the associated HTTP upgrade completes.
+	#[derive(Debug)]
+	pub struct HyperWebsocket {
+		#[pin]
+		inner: hyper::upgrade::OnUpgrade,
+		config: Option<WebSocketConfig>,
+	}
 }
 
 /// Try to upgrade a received `hyper::Request` to a websocket connection.


### PR DESCRIPTION
`pin-project-lite` is a version of `pin-project` written with declarative macros instead of proc macros. It has the same feature set, but removes all proc macro related dependencies. It is used by `tokio` and `hyper` as an alternative to `pin-project`.

After reading #3, I saw that `pin-project-lite` was offered as an option there, but not used. I think that since both `hyper` and `tokio` now use `pin-project-lite`, it should be safe to switch over, and it will clean up the dependency tree for projects using this crate. 